### PR TITLE
Fix i18n/zh_tw translation

### DIFF
--- a/src/main/resources/assets/subtitle-highlight/lang/zh_tw.json
+++ b/src/main/resources/assets/subtitle-highlight/lang/zh_tw.json
@@ -10,7 +10,7 @@
   "formatting_code.dark_gray": "深灰色",
   "formatting_code.blue": "藍色",
   "formatting_code.green": "綠色",
-  "formatting_code.aqua": "天藍色",
+  "formatting_code.aqua": "淺藍色",
   "formatting_code.red": "紅色",
   "formatting_code.light_purple": "粉紅色",
   "formatting_code.yellow": "黃色",


### PR DESCRIPTION
`"formatting_code.aqua":` `"天藍色"` -> `"淺藍色"`